### PR TITLE
fix http_server_stackless_ssl.cpp example

### DIFF
--- a/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
+++ b/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
@@ -249,7 +249,7 @@ class session
 
             // Write the response
             http::async_write(
-                self_.socket_,
+                self_.stream_,
                 *sp,
                 boost::asio::bind_executor(
                     self_.strand_,


### PR DESCRIPTION
write to self_.stream_ instead of the socket_ directly